### PR TITLE
ci: use corepack instead pnpm action

### DIFF
--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -12,12 +12,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - run: corepack enable
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "pnpm"
-
-      - run: corepack enable
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -15,12 +15,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: "pnpm"
 
-      - name: Pnpm Setup
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
-          run_install: false
+      - run: corepack enable
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: "pnpm"
 
-      - name: Pnpm Setup
-        uses: pnpm/action-setup@v2
-        with:
-          version: 8
+      - run: corepack enable
 
       - name: Install deps
         uses: cypress-io/github-action@v6

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,12 +13,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - run: corepack enable
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: "pnpm"
-
-      - run: corepack enable
 
       - name: Install deps
         uses: cypress-io/github-action@v6


### PR DESCRIPTION
Use corepack instead the pnpm action to remove Node 16 Github warning.

Reference: https://github.com/pnpm/action-setup/issues/99
